### PR TITLE
feat: Rewriting DraftSigner/DraftVerifier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,12 +39,12 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           src: "./src/apsig"
-          args: "check --output-file ruff_output.txt --output-format full"
+          args: "check --output-file ruff_check_output.txt --output-format full"
         continue-on-error: true
       
       - name: Output
         run: |
-          echo "#### Ruff Linter" > ruff_output.txt
+          echo "#### Lint Result" > ruff_output.txt
 
           # Add format output
           echo "<details><summary>Not fixable checks</summary>" >> ruff_output.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,31 +7,61 @@ on:
   pull_request:
 
 jobs:
-  run-lint:
+  run-ruff:
     runs-on: ubuntu-latest
-    name: Run Lint
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Run Ruff
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
-      
-      - name: Set up Python environment
-        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          ref: ${{ github.head_ref }}
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
+      - name: Format code
+        uses: astral-sh/ruff-action@v3.0.0
+        with:
+          args: "format"
+          src: "scripts/"
+        continue-on-error: true
 
-      - name: Lint with Ruff
-        id: lint
+      - name: Commit Formatted Code
         run: |
-          ruff check . --output-format=github > lint_report.txt || true
-
-      - name: Post Lint Results
-        run: |
-          comment_body=$(<lint_report.txt)
-          echo "# Lint results\n\`\`\`\n$comment_body\n\`\`\`" | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "refactor: auto formatted by ruff" || exit 0
+          git push origin HEAD:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          src: "./src/apsig"
+          args: "check --output-file ruff_output.txt --output-format full"
+        continue-on-error: true
+      
+      - name: Output
+        run: |
+          echo "#### Ruff Linter" > ruff_output.txt
+
+          # Add format output
+          echo "<details><summary>Not fixable checks</summary>" >> ruff_output.txt
+          echo "" >> ruff_output.txt
+          echo '```' >> ruff_output.txt
+          cat ruff_check_output.txt >> ruff_output.txt
+          echo '```' >> ruff_output.txt
+          echo "" >> ruff_output.txt
+          echo "</details>" >> ruff_output.txt
+
+          file_size=$(wc -m <ruff_output.txt)         
+          if [ "$file_size" -gt 65000 ]; then
+            head -c 65000 ruff_output.txt > temp_ruff_output.txt
+            mv temp_ruff_output.txt ruff_output.txt
+          fi
+
+          gh issue comment ${{ github.event.number }} --body-file ruff_output.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Deprecation
 - `apsig.draft.sign.draftSigner` has been deprecated and will be removed in 1.0, please use `apsig.draft.sign.DraftSigner` instead.
+- `apsig.draft.verify.draftVerifier` has been deprecated and will be removed in 1.0, please use `apsig.draft.verify.Verifier` instead.
 # 0.3.2
 ## Bug Fixed
 - fix: convert header keys to case-insensitive key names during validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# 0.3.3 (unreleased)
+# 0.3.3
 ## Bug Fixed
-- fix: Fixed problem with HTTP signatures not being accepted in some implementations (re)
+
+## Deprecation
+- `apsig.draft.sign.draftSigner` has been deprecated and will be removed in 1.0, please use `apsig.draft.sign.DraftSigner` instead.
 # 0.3.2
 ## Bug Fixed
 - fix: convert header keys to case-insensitive key names during validation

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "e2e"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8b6d1b3f5945fd7e61d74a4532bf87173a32cbd5f0d539e0673e8b856eabcda9"
+content_hash = "sha256:fe0c7e00850039331da18420e804de63a5d0cc11f7ee3f123673dc5a5a3c02e0"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -216,6 +216,7 @@ version = "1.17.1"
 requires_python = ">=3.8"
 summary = "Foreign Function Interface for Python calling C code."
 groups = ["default", "e2e"]
+marker = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\""
 dependencies = [
     "pycparser",
 ]
@@ -859,6 +860,7 @@ version = "2.22"
 requires_python = ">=3.8"
 summary = "C parser in Python"
 groups = ["default", "e2e"]
+marker = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -997,28 +999,6 @@ dependencies = [
 files = [
     {file = "PyLD-2.0.4-py3-none-any.whl", hash = "sha256:6dab9905644616df33f8755489fc9b354ed7d832d387b7d1974b4fbd3b8d2a89"},
     {file = "PyLD-2.0.4.tar.gz", hash = "sha256:311e350f0dbc964311c79c28e86f84e195a81d06fef5a6f6ac2a4f6391ceeacc"},
-]
-
-[[package]]
-name = "pynacl"
-version = "1.5.0"
-requires_python = ">=3.6"
-summary = "Python binding to the Networking and Cryptography (NaCl) library"
-groups = ["default"]
-dependencies = [
-    "cffi>=1.4.1",
-]
-files = [
-    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
-    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -961,13 +961,13 @@ files = [
 
 [[package]]
 name = "pyfill"
-version = "0.1.2"
+version = "0.1.3"
 requires_python = ">=3.9"
 summary = "pyfill is a tool to detect Python versions and automatically replace deprecated features (e.g. datetime.utcnow) with alternative methods."
 groups = ["default"]
 files = [
-    {file = "pyfill-0.1.2-py3-none-any.whl", hash = "sha256:0566902fe6075d3554767d4aa265fbeb7bfb01876e5d07103ba00988f63333cc"},
-    {file = "pyfill-0.1.2.tar.gz", hash = "sha256:e8be1a3f17d1b6afd635c65128ae1432307b2470de3bf328c56d164f111dc347"},
+    {file = "pyfill-0.1.3-py3-none-any.whl", hash = "sha256:f6057ac9ab418855f278a21b02082a80f969b2decd15229a476c9f74a2f353d7"},
+    {file = "pyfill-0.1.3.tar.gz", hash = "sha256:f8416ca329c5c61da9323527b3f8f263f9ac71139d00ac3f5d2fa1398afca274"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "e2e"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fe0c7e00850039331da18420e804de63a5d0cc11f7ee3f123673dc5a5a3c02e0"
+content_hash = "sha256:d53a2db498fe5cc6710f5e0c753c1ffb9047a2821fa02665babf8428baa6b67a"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -999,6 +999,16 @@ dependencies = [
 files = [
     {file = "PyLD-2.0.4-py3-none-any.whl", hash = "sha256:6dab9905644616df33f8755489fc9b354ed7d832d387b7d1974b4fbd3b8d2a89"},
     {file = "PyLD-2.0.4.tar.gz", hash = "sha256:311e350f0dbc964311c79c28e86f84e195a81d06fef5a6f6ac2a4f6391ceeacc"},
+]
+
+[[package]]
+name = "pytz"
+version = "2025.1"
+summary = "World timezone definitions, modern and historical"
+groups = ["default"]
+files = [
+    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
+    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyld[aiohttp,requests]>=2.0.4",
     "pyfill>=0.1.1",
     "typing-extensions>=4.12.2",
+    "pytz>=2025.1",
 ]
 classifiers = [
         'Development Status :: 4 - Beta',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ authors = [
 ]
 dependencies = [
     "cryptography>=43.0.1",
-    "pynacl>=1.5.0",
     "multiformats>=0.3.1.post4",
     "jcs>=0.2.1",
     "pyld[aiohttp,requests]>=2.0.4",
     "pyfill>=0.1.1",
+    "typing-extensions>=4.12.2",
 ]
 classifiers = [
         'Development Status :: 4 - Beta',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "multiformats>=0.3.1.post4",
     "jcs>=0.2.1",
     "pyld[aiohttp,requests]>=2.0.4",
-    "pyfill>=0.1.1",
+    "pyfill>=0.1.3",
     "typing-extensions>=4.12.2",
     "pytz>=2025.1",
 ]

--- a/src/apsig/__init__.py
+++ b/src/apsig/__init__.py
@@ -1,5 +1,5 @@
 from .actor.keytools import KeyUtil
-from .draft.sign import DraftSigner, draftSigner
+from .draft.sign import draftSigner
 from .draft.verify import draftVerifier
 from .ld_signature import LDSignature
 from .proof.sign import ProofSigner
@@ -10,7 +10,6 @@ __all__ = [
     "OIPVerifier",
     "ProofSigner",
     "ProofVerifier",
-    "DraftSigner",
     "draftSigner",
     "draftVerifier",
     "LDSignature",

--- a/src/apsig/__init__.py
+++ b/src/apsig/__init__.py
@@ -1,5 +1,5 @@
 from .actor.keytools import KeyUtil
-from .draft.sign import draftSigner
+from .draft.sign import DraftSigner, draftSigner
 from .draft.verify import draftVerifier
 from .ld_signature import LDSignature
 from .proof.sign import ProofSigner
@@ -10,6 +10,7 @@ __all__ = [
     "OIPVerifier",
     "ProofSigner",
     "ProofVerifier",
+    "DraftSigner",
     "draftSigner",
     "draftVerifier",
     "LDSignature",

--- a/src/apsig/actor/keytools.py
+++ b/src/apsig/actor/keytools.py
@@ -1,4 +1,3 @@
-from typing import Self
 
 from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
 from cryptography.hazmat.primitives import serialization
@@ -9,7 +8,7 @@ from multiformats import multibase, multicodec
 
 class KeyUtil:
     def __init__(
-        self: Self,
+        self,
         public_key: ed25519.Ed25519PublicKey | rsa.RSAPublicKey = None,
         private_key: ed25519.Ed25519PrivateKey | rsa.RSAPrivateKey = None,
     ):
@@ -28,7 +27,7 @@ class KeyUtil:
             self.private_key = private_key
             self.public_key = private_key.public_key()
 
-    def encode_multibase(self: Self, private: bool = False) -> str:
+    def encode_multibase(self, private: bool = False) -> str:
         """multibase encode the key.
 
         Args:
@@ -73,7 +72,7 @@ class KeyUtil:
         return multibase.encode(prefixed, "base58btc")
 
     def decode_multibase(
-        self: Self, data: str
+        self, data: str
     ) -> (
         ed25519.Ed25519PublicKey
         | ed25519.Ed25519PrivateKey

--- a/src/apsig/draft/__init__.py
+++ b/src/apsig/draft/__init__.py
@@ -1,0 +1,7 @@
+from .sign import Signer
+from .verify import Verifier
+
+__all__ = [
+    "Signer",
+    "Verifier"
+]

--- a/src/apsig/draft/sign.py
+++ b/src/apsig/draft/sign.py
@@ -1,20 +1,22 @@
+from typing import Any
+from typing_extensions import deprecated
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 
-from pyfill import datetime
 import base64
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
+import email.utils
 
 class draftSigner:
-    def _generate_digest(body: bytes | str):
-        digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
-        digest.update(body.encode("utf-8") if isinstance(body, str) else body)
-        hash_bytes = digest.finalize()
-        return "SHA-256=" + base64.b64encode(hash_bytes).decode("utf-8")
-
     @staticmethod
-    def sign(private_key: rsa.RSAPrivateKey, method: str, url: str, headers: dict, key_id: str, body: bytes="") -> dict:
+    @deprecated("apsig.draft.sign.draftSigner is deprecated; use apsig.draft.sign.DraftSigner instead. This will be removed in apsig 1.0.")
+    def sign(private_key: rsa.RSAPrivateKey, method: str, url: str, headers: dict, key_id: str, body: bytes=b"") -> dict:
+        signer = DraftSigner(headers=headers, private_key=private_key, method=method, url=url, key_id=key_id, body=body)
+        return signer.sign()
+
+class DraftSigner:
+    def __init__(self, headers: dict[Any, Any], private_key: rsa.RSAPrivateKey, method: str, url: str, key_id: str, body: bytes=b"") -> None:
         """Signs an HTTP request with a digital signature.
 
         Args:
@@ -31,30 +33,61 @@ class draftSigner:
         Raises:
             ValueError: If the signing process fails due to invalid parameters.
         """
-        parsed_url = urlparse(url)
-        request_target = f"(request-target): {method.lower()} {parsed_url.path}"
+        if not headers.get("date") and not headers.get("Date"):
+            headers["date"] = email.utils.formatdate(usegmt=True)
+        self.parsed_url: ParseResult = urlparse(url)
+        self.headers = {
+            **headers,
+            "(request-target)": f"{method.lower()} {self.parsed_url.path}"
+        }
+        self.private_key = private_key
+        self.method = method
+        self.url = url
+        self.key_id = key_id
+        self.body = body
 
-        digest = draftSigner._generate_digest(body)
+        self.__generate_digest(self.body)
 
-        headers["digest"] = digest
-        headers["date"] = datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')
+    def __generate_sign_header(self, signature: str):
+        if not self.headers.get("Host"):
+            self.headers["Host"] = self.parsed_url.netloc
+        self.headers["Signature"] = signature
+        self.headers["Authorization"] = f"Signature {signature}"
 
-        signature_headers = [request_target]
-        for header in headers:
-            signature_headers.append(f"{header}: {headers[header]}")
+    def __sign_document(self, document: bytes):
+        return base64.standard_b64encode(self.private_key.sign(document, padding.PKCS1v15(), hashes.SHA256())).decode("utf-8")
 
-        signature_string = "\n".join(signature_headers).encode("utf-8")
+    def __generate_digest(self, body: bytes | str):
+        if not self.headers.get("digest") and not self.headers.get("Digest"):
+            digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+            digest.update(body.encode("utf-8") if isinstance(body, str) else body)
+            hash_bytes = digest.finalize()
+            self.headers["digest"] = "SHA-256=" + base64.b64encode(hash_bytes).decode("utf-8")
+        else:
+            return self.headers.get("digest")
+    
+    def build_signature(self, key_id: str, signature: str, algorithm: str = "rsa-sha256"):
+        if algorithm != "rsa-sha256":
+            raise NotImplementedError(f"Unsuppored algorithm: {algorithm}")
+        
+        return ",".join([
+            f'keyId="{key_id}"',
+            f'algorithm="{algorithm}"',
+            f'headers="{" ".join(key.lower() for key in self.headers.keys())}"',
+            f'signature="{signature}"'
+        ])
 
-        signature = private_key.sign(signature_string, padding.PKCS1v15(), hashes.SHA256())
-        signature_b64 = base64.b64encode(signature).decode("utf-8")
-        header_keys = []
-        for key in headers.keys():
-            #if key.lower() != "content-type":
-            header_keys.append(key)
+    def build_string(self, strings: dict) -> str:
+        return "\n".join(f"{key.lower()}: {value}" for key, value in strings.items())
 
-        if not headers.get("Host"):
-            headers["Host"] = parsed_url.netloc
-        signature_header = f'keyId="{key_id}",algorithm="rsa-sha256",headers="(request-target) {" ".join(header_keys)}",signature="{signature_b64}"'
-        headers["Signature"] = signature_header
-        headers["Authorization"] = f"Signature {signature_header}" # Misskeyなどでは必要
+    def sign(self) -> dict:
+        signature_string = self.build_string(self.headers).encode("utf-8")
+
+        signature = self.__sign_document(signature_string)
+        signed = self.build_signature(self.key_id, signature)
+        self.__generate_sign_header(signed)
+
+        headers = self.headers.copy()
+        headers.pop("(request-target)")
+
         return headers

--- a/src/apsig/draft/tools.py
+++ b/src/apsig/draft/tools.py
@@ -1,0 +1,20 @@
+import base64
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+
+def calculate_digest(body: bytes | str):
+    digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+    digest.update(body.encode("utf-8") if isinstance(body, str) else body)
+    hash_bytes = digest.finalize()
+    return "SHA-256=" + base64.standard_b64encode(hash_bytes).decode("utf-8")
+
+def build_string(strings: dict, headers: list = []) -> str:
+    if headers:
+        header_list = []
+        for key in headers:
+            header_list.append(f"{key}: {strings[key.lower()]}")
+        result = "\n".join(header_list)
+    else:
+        result = "\n".join(f"{key.lower()}: {value}" for key, value in strings.items())
+    return result

--- a/tests/test_draft.py
+++ b/tests/test_draft.py
@@ -1,42 +1,90 @@
 import unittest
+import email.utils
 
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 
-from apsig import draftSigner, draftVerifier
+from apsig.draft import Signer, Verifier
 
 class TestSignatureFunctions(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.private_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=2048,
-            backend=default_backend()
+            public_exponent=65537, key_size=2048, backend=default_backend()
         )
         cls.public_key = cls.private_key.public_key()
 
         cls.public_pem = cls.public_key.public_bytes(
             encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo
-        ).decode('utf-8')
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode("utf-8")
 
     def test_create_and_verify_signature(self):
+        date = email.utils.formatdate(usegmt=True)
+
         method = "POST"
         url = "https://example.com/api/resource"
         headers = {
             "Content-Type": "application/json",
-            "Date": "Wed, 21 Oct 2015 07:28:00 GMT"
+            "Date": date,
         }
         body = '{"key": "value"}'
 
-        signed_headers = draftSigner.sign(self.private_key, method, url, headers, "https://example.com/users/johndoe#main-key", body)
+        signer = Signer(
+            headers=headers,
+            private_key=self.private_key,
+            method=method,
+            url=url,
+            key_id="https://example.com/users/johndoe#main-key",
+            body=body,
+        )
 
-        is_valid, message = draftVerifier.verify(public_pem=self.public_pem, method=method, url=url, headers=signed_headers, body=body.encode("utf-8"))
+        signed_headers = signer.sign()
+        verifier = Verifier(
+            public_pem=self.public_pem,
+            method=method,
+            url=url,
+            headers=signed_headers,
+            body=body.encode("utf-8"),
+        )
+
+        is_valid, message = verifier.verify()
 
         self.assertTrue(is_valid)
         self.assertEqual(message, "Signature is valid")
+
+    def test_too_far_date(self):
+        method = "POST"
+        url = "https://example.com/api/resource"
+        headers = {
+            "Content-Type": "application/json",
+            "Date": "Wed, 21 Oct 2015 07:28:00 GMT",
+        }
+        body = '{"key": "value"}'
+
+        signer = Signer(
+            headers=headers,
+            private_key=self.private_key,
+            method=method,
+            url=url,
+            key_id="https://example.com/users/johndoe#main-key",
+            body=body,
+        )
+
+        signed_headers = signer.sign()
+        verifier = Verifier(
+            public_pem=self.public_pem,
+            method=method,
+            url=url,
+            headers=signed_headers,
+            body=body.encode("utf-8"),
+        )
+
+        is_valid, message = verifier.verify()
+
+        self.assertFalse(is_valid)
+        self.assertEqual(message, "Date header is too far from current time")
 
     def test_verify_invalid_signature(self):
         method = "POST"
@@ -44,11 +92,19 @@ class TestSignatureFunctions(unittest.TestCase):
         headers = {
             "Content-Type": "application/json",
             "Date": "Wed, 21 Oct 2015 07:28:00 GMT",
-            "Signature": 'keyId="your-key-id",algorithm="rsa-sha256",headers="(request-target) Content-Type Date",signature="invalid_signature"'
+            "Signature": 'keyId="your-key-id",algorithm="rsa-sha256",headers="(request-target) Content-Type Date",signature="invalid_signature"',
         }
         body = '{"key": "value"}'
 
-        is_valid, message = draftVerifier.verify(self.public_pem, method, url, headers, body.encode("utf-8"))
+        verifier = Verifier(
+            public_pem=self.public_pem,
+            method=method,
+            url=url,
+            headers=headers,
+            body=body.encode("utf-8"),
+        )
+
+        is_valid, message = verifier.verify()
 
         self.assertFalse(is_valid)
         self.assertEqual(message, "Invalid signature")
@@ -58,14 +114,22 @@ class TestSignatureFunctions(unittest.TestCase):
         url = "https://example.com/api/resource"
         headers = {
             "Content-Type": "application/json",
-            "Date": "Wed, 21 Oct 2015 07:28:00 GMT"
+            "Date": "Wed, 21 Oct 2015 07:28:00 GMT",
         }
         body = '{"key": "value"}'
+        verifier = Verifier(
+            public_pem=self.public_pem,
+            method=method,
+            url=url,
+            headers=headers,
+            body=body.encode("utf-8"),
+        )
 
-        is_valid, message = draftVerifier.verify(self.public_pem, method, url, headers, body.encode("utf-8"))
+        is_valid, message = verifier.verify()
 
         self.assertFalse(is_valid)
         self.assertEqual(message, "Signature header is missing")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
DraftSignerを書き直し、Mastodon/Misskeyで正常に動作するようにします。これに伴ってDraftVerifierもDraftSignerのような構造に変更します。

Rewrite DraftSigner to work properly with Mastodon/Misskey. Along with this, DraftVerifier will be changed to a DraftSigner-like structure.